### PR TITLE
Use IsValueType rather than IsByRef to cast from null to None

### DIFF
--- a/Bearded.Monads.Tests/OptionTests.cs
+++ b/Bearded.Monads.Tests/OptionTests.cs
@@ -561,6 +561,17 @@ namespace Bearded.Monads.Tests
             b = Option<string>.None;
             Assert.False(b);
         }
+
+        [Test]
+        public void ImplicitCastNull()
+        {
+            string n = null;
+            Option<string> none = n;
+
+            Assert.False(none);
+        }
+      
+
         #region Monad laws
         [Test]
         public void LeftIdentity()

--- a/Bearded.Monads/Option.cs
+++ b/Bearded.Monads/Option.cs
@@ -128,7 +128,7 @@ namespace Bearded.Monads
 
         public static implicit operator Option<A>(A value)
         {
-            if (typeof (A).IsByRef && Equals(null, value))
+            if (!(typeof (A).IsValueType) && Equals(null, value))
                 return None;
 
             return Return(value);


### PR DESCRIPTION
IsByRef is for determining if a paramater is passed by reference, use IsValueType instead