### PR TITLE
Add Decimal Parsing with MaybeDecimal

### DIFF
--- a/Bearded.Monads/MaybeParseExtensions.cs
+++ b/Bearded.Monads/MaybeParseExtensions.cs
@@ -34,6 +34,16 @@ namespace Bearded.Monads
             return Option<float>.None;
         }
 
+        public static Option<decimal> MaybeDecimal(this string value)
+        {
+            decimal val;
+
+            if (decimal.TryParse(value, out val))
+                return val;
+
+            return Option<decimal>.None;
+        }
+
         public static Option<long> MaybeLong(this string value)
         {
             long val;


### PR DESCRIPTION
lolrm is using `MaybeCast<decimal>` that works only if the field is a Decimal Type, it will not try to cast an integer to Decimal, it'll just return a None. 