### PR TITLE
Added either applicatives

### DIFF
--- a/Bearded.Monads.Tests/EitherApplicativeTests.cs
+++ b/Bearded.Monads.Tests/EitherApplicativeTests.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using static Bearded.Monads.Syntax;
+
+namespace Bearded.Monads.Tests
+{
+    public class EitherApplicativeTests
+    {
+        private Either<string,string> NewEither(string value) =>
+            Either<string,string>.CreateSuccess(value);
+
+        [Fact]
+        public void OneArg()
+        {
+            var result = EitherArg(NewEither("A"))
+                            .Then(a => a + "!");
+            var expected = "A!";
+
+            Assert.True(result.IsSuccess);
+            Assert.False(result.IsError);
+
+            Assert.Equal(expected, result.AsSuccess.Value);
+        }
+
+        [Fact]
+        public void TwoArgs()
+        {
+            var result = EitherArg(NewEither("A"))
+                            .And(NewEither("B"))
+                            .Then((a, b) => a + b + "!");
+            var expected = "AB!";
+
+            Assert.True(result.IsSuccess);
+            Assert.False(result.IsError);
+
+            Assert.Equal(expected, result.AsSuccess.Value);
+        }
+        
+        [Fact]
+        public void ThreeArgs()
+        {
+            var result = EitherArg(NewEither("A"))
+                            .And(NewEither("B"))
+                            .And(NewEither("C"))
+                            .Then((a, b, c) => a + b + c + "!");
+            var expected = "ABC!";
+
+            Assert.True(result.IsSuccess);
+            Assert.False(result.IsError);
+
+            Assert.Equal(expected, result.AsSuccess.Value);
+        }
+    
+        [Fact]
+        public void FourArgs()
+        {
+            var result = EitherArg(NewEither("A"))
+                            .And(NewEither("B"))
+                            .And(NewEither("C"))
+                            .And(NewEither("D"))
+                            .Then((a, b, c, d) => a + b + c + d + "!");
+            var expected = "ABCD!";
+
+            Assert.True(result.IsSuccess);
+            Assert.False(result.IsError);
+
+            Assert.Equal(expected, result.AsSuccess.Value);
+        }
+
+        [Fact]
+        public void FiveArgs()
+        {
+            var result = EitherArg(NewEither("A"))
+                            .And(NewEither("B"))
+                            .And(NewEither("C"))
+                            .And(NewEither("D"))
+                            .And(NewEither("E"))
+                            .Then((a, b, c, d, e) => a + b + c + d + e + "!");
+            var expected = "ABCDE!";
+
+            Assert.True(result.IsSuccess);
+            Assert.False(result.IsError);
+
+            Assert.Equal(expected, result.AsSuccess.Value);
+        }
+
+        [Fact]
+        public void SixArgs()
+        {
+            var result = EitherArg(NewEither("A"))
+                            .And(NewEither("B"))
+                            .And(NewEither("C"))
+                            .And(NewEither("D"))
+                            .And(NewEither("E"))
+                            .And(NewEither("F"))
+                            .Then((a, b, c, d, e, f) => a + b + c + d + e + f + "!");
+            var expected = "ABCDEF!";
+
+            Assert.True(result.IsSuccess);
+            Assert.False(result.IsError);
+
+            Assert.Equal(expected, result.AsSuccess.Value);
+        }
+
+        [Fact]
+        public void SevenArgs()
+        {
+            var result = EitherArg(NewEither("A"))
+                            .And(NewEither("B"))
+                            .And(NewEither("C"))
+                            .And(NewEither("D"))
+                            .And(NewEither("E"))
+                            .And(NewEither("F"))
+                            .And(NewEither("G"))
+                            .Then((a, b, c, d, e, f, g) => a + b + c + d + e + f + g + "!");
+            var expected = "ABCDEFG!";
+
+            Assert.True(result.IsSuccess);
+            Assert.False(result.IsError);
+
+            Assert.Equal(expected, result.AsSuccess.Value);
+        }
+
+        
+        [Fact]
+        public void OneErrorArg()
+        {
+            var result = EitherArg(Either<string,string>.CreateError("Error"))
+                            .Then(a => a + "!");
+            var expected = "Error";
+
+            Assert.False(result.IsSuccess);
+            Assert.True(result.IsError);
+
+            Assert.Equal(expected, result.AsError.Value);
+        }
+        
+
+        [Fact]
+        public void SevenArgsOneError()
+        {
+            var result = EitherArg(NewEither("A"))
+                            .And(NewEither("B"))
+                            .And(NewEither("C"))
+                            .And(Either<string,string>.CreateError("D IS ERROR"))
+                            .And(NewEither("E"))
+                            .And(NewEither("F"))
+                            .And(NewEither("G"))
+                            .Then((a, b, c, d, e, f, g) => a + b + c + d + e + f + g + "!");
+            var expected = "D IS ERROR";
+
+            Assert.False(result.IsSuccess);
+            Assert.True(result.IsError);
+
+            Assert.Equal(expected, result.AsError.Value);
+        }
+
+        [Fact]
+        public void SevenArgsTwoErrors()
+        {
+            var result = EitherArg(NewEither("A"))
+                            .And(NewEither("B"))
+                            .And(NewEither("C"))
+                            .And(Either<string,string>.CreateError("D IS ERROR"))
+                            .And(NewEither("E"))
+                            .And(NewEither("F"))
+                            .And(Either<string,string>.CreateError("G IS ERROR"))
+                            .Then((a, b, c, d, e, f, g) => a + b + c + d + e + f + g + "!");
+            var expected = "D IS ERROR";
+
+            Assert.False(result.IsSuccess);
+            Assert.True(result.IsError);
+
+            Assert.Equal(expected, result.AsError.Value);
+        }
+    }
+}

--- a/Bearded.Monads/EitherApplicative.cs
+++ b/Bearded.Monads/EitherApplicative.cs
@@ -1,0 +1,208 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Bearded.Monads
+{
+    public class EitherApplicative
+    {
+        public static EitherApplicative<A,Error> From<A,Error>(Either<A,Error> incoming) =>
+            new EitherApplicative<A,Error>(incoming);
+    }
+
+    public static class EitherApplicativeExtensions
+    {
+        public static EitherApplicative<A,B,Error> And<A,B,Error>(this Either<A,Error> a, Either<B,Error> b) =>
+            new EitherApplicative<A,B,Error>(a, b);
+    }
+
+    public class EitherApplicative<A,Error>
+    {
+        readonly Either<A,Error> a;
+
+        public EitherApplicative(Either<A,Error> a)
+        {
+            this.a = a;
+        }
+
+        [DebuggerStepThrough,MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Either<B,Error> Then<B>(Func<A,B> f) => a.Select(f);
+
+        [DebuggerStepThrough,MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public EitherApplicative<A,B,Error> And<B>(Either<B, Error> b) =>
+            new EitherApplicative<A,B,Error>(a, b);
+    }
+
+    public class EitherApplicative<A,B,Error>
+    {
+        readonly Either<A,Error> a;
+        readonly Either<B,Error> b;
+
+        public EitherApplicative(Either<A,Error> a, Either<B,Error> b)
+        {
+            this.a = a;
+            this.b = b;
+        }
+
+        [DebuggerStepThrough,MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Either<C,Error> Then<C>(Func<A, B, C> func) =>
+            from a_ in a
+            from b_ in b
+            select func(a_, b_);
+
+        [DebuggerStepThrough,MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public EitherApplicative<A,B,C,Error> And<C>(Either<C,Error> c) =>
+            new EitherApplicative<A,B,C,Error>(a, b, c);
+    }
+
+    public class EitherApplicative<A,B,C,Error>
+    {
+        readonly Either<A,Error> a;
+        readonly Either<B,Error> b;
+        readonly Either<C,Error> c;
+
+        public EitherApplicative(Either<A,Error> a, Either<B,Error> b, Either<C,Error> c)
+        {
+            this.a = a;
+            this.b = b;
+            this.c = c;
+        }
+
+        [DebuggerStepThrough,MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Either<D,Error> Then<D>(Func<A, B, C, D> func) =>
+            from a_ in a
+            from b_ in b
+            from c_ in c
+            select func(a_, b_, c_);
+
+        [DebuggerStepThrough,MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public EitherApplicative<A,B,C,D,Error> And<D>(Either<D,Error> d) =>
+            new EitherApplicative<A,B,C,D,Error>(a, b, c, d);
+    }
+
+    public class EitherApplicative<A,B,C,D,Error>
+    {
+        readonly Either<A,Error> a;
+        readonly Either<B,Error> b;
+        readonly Either<C,Error> c;
+        readonly Either<D,Error> d;
+
+        public EitherApplicative(Either<A,Error> a, Either<B,Error> b, Either<C,Error> c, Either<D,Error> d)
+        {
+            this.a = a;
+            this.b = b;
+            this.c = c;
+            this.d = d;
+        }
+
+        [DebuggerStepThrough,MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Either<E,Error> Then<E>(Func<A, B, C, D, E> func) =>
+            from a_ in a
+            from b_ in b
+            from c_ in c
+            from d_ in d
+            select func(a_, b_, c_, d_);
+
+        [DebuggerStepThrough,MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public EitherApplicative<A,B,C,D,E,Error> And<E>(Either<E,Error> e) =>
+            new EitherApplicative<A,B,C,D,E,Error>(a, b, c, d, e);
+    }
+
+    public class EitherApplicative<A,B,C,D,E,Error>
+    {
+        readonly Either<A,Error> a;
+        readonly Either<B,Error> b;
+        readonly Either<C,Error> c;
+        readonly Either<D,Error> d;
+        readonly Either<E,Error> e;
+
+        public EitherApplicative(Either<A,Error> a, Either<B,Error> b, Either<C,Error> c, Either<D,Error> d, Either<E,Error> e)
+        {
+            this.a = a;
+            this.b = b;
+            this.c = c;
+            this.d = d;
+            this.e = e;
+        }
+
+        [DebuggerStepThrough,MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Either<F,Error> Then<F>(Func<A, B, C, D, E, F> func) =>
+            from a_ in a
+            from b_ in b
+            from c_ in c
+            from d_ in d
+            from e_ in e
+            select func(a_, b_, c_, d_, e_);
+
+        [DebuggerStepThrough,MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public EitherApplicative<A,B,C,D,E,F,Error> And<F>(Either<F,Error> f) =>
+            new EitherApplicative<A,B,C,D,E,F,Error>(a, b, c, d, e, f);
+    }
+
+    public class EitherApplicative<A,B,C,D,E,F,Error>
+    {
+        readonly Either<A,Error> a;
+        readonly Either<B,Error> b;
+        readonly Either<C,Error> c;
+        readonly Either<D,Error> d;
+        readonly Either<E,Error> e;
+        readonly Either<F,Error> f;
+
+        public EitherApplicative(Either<A,Error> a, Either<B,Error> b, Either<C,Error> c, Either<D,Error> d, Either<E,Error> e, Either<F,Error> f)
+        {
+            this.a = a;
+            this.b = b;
+            this.c = c;
+            this.d = d;
+            this.e = e;
+            this.f = f;
+        }
+
+        [DebuggerStepThrough,MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Either<G,Error> Then<G>(Func<A, B, C, D, E, F, G> func) =>
+            from a_ in a
+            from b_ in b
+            from c_ in c
+            from d_ in d
+            from e_ in e
+            from f_ in f
+            select func(a_, b_, c_, d_, e_, f_);
+
+        [DebuggerStepThrough,MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public EitherApplicative<A,B,C,D,E,F,G,Error> And<G>(Either<G,Error> g) =>
+            new EitherApplicative<A,B,C,D,E,F,G,Error>(a, b, c, d, e, f, g);
+    }
+
+    public class EitherApplicative<A,B,C,D,E,F,G,Error>
+    {
+        readonly Either<A,Error> a;
+        readonly Either<B,Error> b;
+        readonly Either<C,Error> c;
+        readonly Either<D,Error> d;
+        readonly Either<E,Error> e;
+        readonly Either<F,Error> f;
+        readonly Either<G,Error> g;
+
+        public EitherApplicative(Either<A,Error> a, Either<B,Error> b, Either<C,Error> c, Either<D,Error> d, Either<E,Error> e, Either<F,Error> f, Either<G,Error> g)
+        {
+            this.a = a;
+            this.b = b;
+            this.c = c;
+            this.d = d;
+            this.e = e;
+            this.f = f;
+            this.g = g;
+        }
+
+        [DebuggerStepThrough,MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Either<H,Error> Then<H>(Func<A, B, C, D, E, F, G, H> func) =>
+            from a_ in a
+            from b_ in b
+            from c_ in c
+            from d_ in d
+            from e_ in e
+            from f_ in f
+            from g_ in g
+            select func(a_, b_, c_, d_, e_, f_, g_);
+    }
+}

--- a/Bearded.Monads/Syntax.cs
+++ b/Bearded.Monads/Syntax.cs
@@ -31,6 +31,9 @@ namespace Bearded.Monads
         public static OptionalApplicative<A> Optionally<A>(Option<A> option)
             => new OptionalApplicative<A>(option);
 
+        public static EitherApplicative<A,Error> EitherArg<A,Error>(Either<A,Error> either)
+            => new EitherApplicative<A,Error>(either);
+
         public static AsyncApplicative<A> Asynquence<A>(Task<A> callback) =>
             new AsyncApplicative<A>(callback);
 


### PR DESCRIPTION
This is useful when you get a bunch of lifted variables and want to use them. 

For example:
```C#
var userId = GetLoggedInUserId() // Either<int, string>
var profile = ValidateProfile(profileFromPost) // Either<Profile, string>
var result = UpdateProfile(userId, profile) // can't do this right now
```
But with EitherApplicative...
```C#
var result = EitherArg(GetLoggedInUserId()) 
                   .And(ValidateProfile(profileFromPost))
                   .Then((userId, profile) => UpdateProfile(userId, profile));
```
